### PR TITLE
Parametrized the checker script to have it check against base branch in PRs

### DIFF
--- a/bin/proxify-cs-checker
+++ b/bin/proxify-cs-checker
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
-ADDED=$(git diff --diff-filter=A --name-only origin/staging -- '*.php')
-CHANGED=$(git diff --diff-filter=Mda --name-only origin/staging -- '*.php')
+ADDED=$(git diff --diff-filter=A --name-only origin/$1 -- '*.php')
+CHANGED=$(git diff --diff-filter=Mda --name-only origin/$1 -- '*.php')
 
 PACKAGE_PATH="./vendor/bin/pint"
 


### PR DESCRIPTION
Uses $1 to get the first argument and we'll pass in the GITHUB_BASE_REF from the github action.